### PR TITLE
Dynamic proxy now creates a subdomain link instead of path.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -45,7 +45,8 @@ type DynamicReverseProxy struct {
 	Target         string
 	User           int64
 	JobId          int64
-	KeepBase       bool
+	ServicePrefix  string
+	ProxyType      string
 	DcMasterClient dcrpc.DcMasterRPCClient
 	GrpcConn       *grpc.ClientConn // TODO: Put this into an interface
 }


### PR DESCRIPTION
uses crc for creating hash so that the url is shorter.
creates a subdomain of the type <hash>.<jobid>.svc.<ams>

```
2025/04/27 05:59:02 logger.go:34: server: Got a dynamic proxy path register
2025/04/27 05:59:02 logger.go:34: server: Creating reverse proxy for target: svc:build:http://10.128.0.90:7226/
2025/04/27 05:59:02 logger.go:34: server: Allowing user 1 access to: 10.128.0.90 7226
2025/04/27 05:59:02 logger.go:34: server: Granted access to resource 10.128.0.90:7226 for user: 1, job: 39508
2025/04/27 05:59:02 logger.go:34: server: Connecting to resource host 10.128.0.90.
2025/04/27 05:59:02 logger.go:34: server: Registering for pid: 246dd98b42204202
2025/04/27 05:59:02 logger.go:34: server: Generating fqdn prefix: v%!(EXTRA string=246dd98b42204202.39508.svc)
```


![image](https://github.com/user-attachments/assets/5d0f7b25-549f-4265-8d05-fb50b1ca2008)
